### PR TITLE
Add route for AppendEntries RPC and server tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,28 +1,4 @@
-from fastapi import FastAPI, HTTPException
-from store import Store
-from raft import State, AppendEntries
-
-app = FastAPI()
-store = Store()
-state = State()
+from server import build_app
 
 
-@app.get("/")
-async def db_get(key: str):
-    """reads the specified value"""
-    v = store.read(key)
-    if not v:
-        raise HTTPException(status_code=404, detail="Not found")
-    return v
-
-
-@app.post("/", status_code=201)
-async def db_upsert(key: str, value: str):
-    """inserts the specified value without checking for previous existence"""
-    store.upsert(key, value)
-
-
-@app.delete("/", status_code=204)
-async def db_delete(key: str):
-    """deletes specified key without checking for existence"""
-    store.delete(key)
+app = build_app()

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,6 +36,17 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "certifi"
+version = "2023.5.7"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.4"
 description = "Composable command line interface toolkit"
@@ -180,6 +191,27 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "0.17.3"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpcore-0.17.3-py3-none-any.whl", hash = "sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87"},
+    {file = "httpcore-0.17.3.tar.gz", hash = "sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888"},
+]
+
+[package.dependencies]
+anyio = ">=3.0,<5.0"
+certifi = "*"
+h11 = ">=0.13,<0.15"
+sniffio = "==1.*"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+
+[[package]]
 name = "httptools"
 version = "0.6.0"
 description = "A collection of framework independent HTTP protocol utils."
@@ -225,6 +257,29 @@ files = [
 
 [package.extras]
 test = ["Cython (>=0.29.24,<0.30.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.24.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
+]
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "idna"
@@ -802,4 +857,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b5d6278730e245661c7098c3fc6cfbd6421ae106d42b8032084bcd3c1490c511"
+content-hash = "25a06692aad5d09927c8cb5295110ef73a4bd35d502ef3941f7ed59a50004e1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ mypy = "^1.4.1"
 fastapi = "^0.100.0"
 uvicorn = {extras = ["standard"], version = "^0.22.0"}
 pytest-cov = "^4.1.0"
+httpx = "^0.24.1"
 
 
 [build-system]

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Union
+from store import Store
+from raft import State, AppendEntries, AppendEntriesResponse
+
+
+class ReadResponse(BaseModel):
+    value: Union[str, None]
+
+
+def build_app():
+    app = FastAPI()
+    store = Store()
+    state = State()
+
+    # ----- DB Router -----
+    @app.get("/")
+    async def db_get(key: str) -> ReadResponse:
+        """reads the specified value"""
+        v = store.read(key)
+        if not v:
+            raise HTTPException(status_code=404, detail="Not found")
+        return ReadResponse(value=v)
+
+    @app.post("/", status_code=201)
+    async def db_upsert(key: str, value: str):
+        """inserts the specified value without checking for previous existence"""
+        store.upsert(key, value)
+
+    @app.delete("/", status_code=204)
+    async def db_delete(key: str):
+        """deletes specified key without checking for existence"""
+        store.delete(key)
+
+    # ----- Raft Router -----
+    @app.post("/rpc/append")
+    async def rpc_append_entries(req: AppendEntries) -> AppendEntriesResponse:
+        return state.append_entries_receiver(req)
+
+    return app

--- a/tests/test_raft_server.py
+++ b/tests/test_raft_server.py
@@ -1,0 +1,25 @@
+import os
+import sys
+sys.path.append(os.path.realpath(os.path.dirname(__file__)+"/.."))
+
+from fastapi.testclient import TestClient  # noqa
+from server import build_app  # noqa
+
+
+def test_rpc_append_entries():
+    """this corresponds to test_append_entries_empty in test_raft.py --
+    see that file for comprehensive test cases on the append handler"""
+    app = build_app()
+
+    client = TestClient(app)
+
+    body = {
+            "term": 1,
+            "leaderId": 0,
+            "prevLogIndex": -1,
+            "prevLogTerm": 0,
+            "leaderCommit": -1
+    }
+    res = client.post("/rpc/append", json=body)
+    assert res.status_code == 200
+    assert res.json()["success"]

--- a/tests/test_store_server.py
+++ b/tests/test_store_server.py
@@ -1,0 +1,40 @@
+import os
+import sys
+sys.path.append(os.path.realpath(os.path.dirname(__file__)+"/.."))
+
+from fastapi.testclient import TestClient  # noqa
+from server import build_app  # noqa
+
+
+def test_store_read_empty():
+    app = build_app()
+
+    client = TestClient(app)
+    response = client.get("/?key=this")
+    assert response.status_code == 404
+
+
+def test_store_write():
+    app = build_app()
+
+    client = TestClient(app)
+    response = client.post("/?key=this&value=that")
+    assert response.status_code == 201
+
+
+def test_store_read_after_write():
+    app = build_app()
+
+    client = TestClient(app)
+    client.post("/?key=this&value=that")
+    response = client.get("/?key=this")
+    assert response.status_code == 200
+    assert response.json()["value"] == 'that'
+
+
+def test_delete():
+    app = build_app()
+
+    client = TestClient(app)
+    response = client.delete("/?key=this")
+    assert response.status_code == 204


### PR DESCRIPTION
- Add `httpx` for server tests
- Refactor server build method into separate module for import into tests
- Add a happy-path/canary test for each server route