### PR TITLE
Refactor code to separate server code from raft state

### DIFF
--- a/raft/__init__.py
+++ b/raft/__init__.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from pydantic import BaseModel
 from typing import Dict, List, Union
 
 
@@ -15,32 +14,25 @@ class Op(Enum):
     DELETE = 2
 
 
-class LogEntry(BaseModel):
-    op: Op
-    key: str
-    value: Union[str, None]
-    term: int
+class AppendResult:
+    def __init__(self, term: int, success: bool):
+        self.term = term
+        self.success = success
 
 
-class AppendEntries(BaseModel):
-    term: int
-    leaderId: int
-    prevLogIndex: int
-    prevLogTerm: int
-    entries: List[LogEntry] = list()
-    leaderCommit: int
-
-
-class AppendEntriesResponse(BaseModel):
-    term: int
-    success: bool
+class Entry:
+    def __init__(self, op: Op, key: str, value: Union[str, None], term: int):
+        self.op = op
+        self.key = key
+        self.value = value
+        self.term = term
 
 
 class State:
     role: Role = Role.FOLLOWER
     currentTerm: int = 0
     votedFor: int
-    log: List[LogEntry] = list()
+    log: List[Entry] = list()
     commitIndex: int = -1
     # application not yet implemented
     lastApplied: int = -1
@@ -48,28 +40,38 @@ class State:
     nextIndex: Dict[str, int] = dict()
     matchIndex: Dict[str, int] = dict()
 
-    def append_entries_receiver(self, ae: AppendEntries) -> AppendEntriesResponse:
-        if ae.term < self.currentTerm:
+    def append_entries(
+            self,
+            term: int,
+            leader_id: int,  # noqa -- to be used
+            prev_log_index: int,
+            prev_log_term: int,
+            entries: List[Entry],
+            leader_commit: int) -> AppendResult:
+        if term < self.currentTerm:
             # ae from expired leader
-            return AppendEntriesResponse(term=self.currentTerm, success=False)
-        if ae.term > self.currentTerm:
+            return AppendResult(self.currentTerm, False)
+        if term > self.currentTerm:
             # election happened, become follower
-            self.currentTerm = ae.term
+            self.currentTerm = term
             self.role = Role.FOLLOWER
-        if ae.prevLogIndex == -1:
+        if prev_log_index == -1:
             # only before any logs have been shipped
-            self.log.extend(ae.entries)
-            return AppendEntriesResponse(term=self.currentTerm, success=True)
+            self.log.extend(entries)
+            return AppendResult(self.currentTerm, True)
         try:
-            self.log[ae.prevLogIndex]
+            prev_log = self.log[prev_log_index]
         except IndexError:
             # previous entry missing
             success = False
         else:
-            success = True
-        if len(self.log) > ae.prevLogIndex:
-            self.log = self.log[:ae.prevLogIndex+1]
-            self.log.extend(ae.entries)
-        if ae.leaderCommit > self.commitIndex:
-            self.commitIndex = min(ae.leaderCommit, len(self.log))
-        return AppendEntriesResponse(term=self.currentTerm, success=success)
+            # entry found, check term
+            success = prev_log.term == prev_log_term
+            if not success:
+                self.log = self.log[:prev_log_index + 1]
+        if len(self.log) > prev_log_index:
+            self.log = self.log[:prev_log_index+1]
+            self.log.extend(entries)
+        if leader_commit > self.commitIndex:
+            self.commitIndex = min(leader_commit, len(self.log))
+        return AppendResult(self.currentTerm, success)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,12 +1,43 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import Union
+from typing import List, Union
 from store import Store
-from raft import State, AppendEntries, AppendEntriesResponse
+from raft import Entry, State, Op
 
 
+# all FastAPI and Pydantic code should be limited to the server module
 class ReadResponse(BaseModel):
     value: Union[str, None]
+
+
+class LogEntry(BaseModel):
+    op: Op
+    key: str
+    value: Union[str, None]
+    term: int
+
+    def as_entry(self) -> Entry:
+        """
+        re-serialization to prevent leaking pydantic model into internal code,
+        may be technically unnecessary due to duck-typing, but this can be used
+        to satisfy the type-checker by doing something along the lines of
+        [le.as_entry() for le in log_entries]
+        """
+        return Entry(self.op, self.key, self.value, self.term)
+
+
+class AppendEntries(BaseModel):
+    term: int
+    leaderId: int
+    prevLogIndex: int
+    prevLogTerm: int
+    entries: List[LogEntry] = list()
+    leaderCommit: int
+
+
+class AppendEntriesResponse(BaseModel):
+    term: int
+    success: bool
 
 
 def build_app():
@@ -36,6 +67,14 @@ def build_app():
     # ----- Raft Router -----
     @app.post("/rpc/append")
     async def rpc_append_entries(req: AppendEntries) -> AppendEntriesResponse:
-        return state.append_entries_receiver(req)
+        """handles AppendEntry RPC requests for writes and heartbeats"""
+        res = state.append_entries(
+            term=req.term,
+            leader_id=req.leaderId,
+            prev_log_index=req.prevLogIndex,
+            prev_log_term=req.prevLogTerm,
+            entries=req.entries,  # noqa  -- see note in LogEntry.as_entry
+            leader_commit=req.leaderCommit)
+        return AppendEntriesResponse(term=res.term, success=res.success)
 
     return app

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -13,14 +13,13 @@ def test_append_entries_empty():
     # simulate a previous successful election
     s.currentTerm = term
 
-    ae = AppendEntries(
+    res = s.append_entries(
         term=term,
-        leaderId=0,
-        prevLogIndex=-1,
-        prevLogTerm=0,
-        leaderCommit=-1)
-
-    res = s.append_entries_receiver(ae)
+        leader_id=0,
+        prev_log_index=-1,
+        prev_log_term=0,
+        entries=list(),
+        leader_commit=-1)
     assert res.success
     assert res.term == term
 
@@ -33,16 +32,15 @@ def test_append_entries_nonempty_first():
     s = State()
     s.currentTerm = term
 
-    le = LogEntry(op=Op.WRITE, key='this', value='that', term=term)
-    ae = AppendEntries(
-        term=term,
-        leaderId=0,
-        prevLogIndex=-1,
-        prevLogTerm=0,
-        entries=[le],
-        leaderCommit=-1)
+    le = Entry(op=Op.WRITE, key='this', value='that', term=term)
 
-    res = s.append_entries_receiver(ae)
+    res = s.append_entries(
+        term=term,
+        leader_id=0,
+        prev_log_index=-1,
+        prev_log_term=0,
+        entries=[le],
+        leader_commit=-1)
     assert res.success
     assert res.term == term
     assert len(s.log) == 1
@@ -54,22 +52,21 @@ def test_append_entries_nonempty():
     """test non-empty heartbeat condition, e.g.: successful election and
     previous log entries, subsequent non-empty append, same term"""
     term = 1
-    le0 = LogEntry(op=Op.WRITE, key='this', value='that', term=term)
+    le0 = Entry(op=Op.WRITE, key='this', value='that', term=term)
     # simulate a previous successful election and write
     s = State()
     s.currentTerm = term
     s.log = [le0]
 
-    le1 = LogEntry(op=Op.DELETE, key='this', value=None, term=term)
-    ae = AppendEntries(
-        term=term,
-        leaderId=0,
-        prevLogIndex=0,
-        prevLogTerm=1,
-        entries=[le1],
-        leaderCommit=0)
+    le1 = Entry(op=Op.DELETE, key='this', value=None, term=term)
 
-    res = s.append_entries_receiver(ae)
+    res = s.append_entries(
+        term=term,
+        leader_id=0,
+        prev_log_index=0,
+        prev_log_term=1,
+        entries=[le1],
+        leader_commit=0)
     assert res.success
     assert res.term == term
     assert len(s.log) == 2
@@ -83,22 +80,21 @@ def test_append_entries_nonempty():
 def test_append_entries_nonempty_missing():
     """test missing prevLogIndex"""
     term = 1
-    le0 = LogEntry(op=Op.WRITE, key='this', value='that', term=term)
+    le0 = Entry(op=Op.WRITE, key='this', value='that', term=term)
     # simulate a previous successful election and write
     s = State()
     s.currentTerm = term
     s.log = [le0]
 
-    le1 = LogEntry(op=Op.DELETE, key='this', value=None, term=term)
-    ae = AppendEntries(
-        term=term,
-        leaderId=0,
-        prevLogIndex=1,
-        prevLogTerm=1,
-        entries=[le1],
-        leaderCommit=0)
+    le1 = Entry(op=Op.DELETE, key='this', value=None, term=term)
 
-    res = s.append_entries_receiver(ae)
+    res = s.append_entries(
+        term=term,
+        leader_id=0,
+        prev_log_index=1,
+        prev_log_term=1,
+        entries=[le1],
+        leader_commit=0)
     assert not res.success
     assert res.term == term
     assert len(s.log) == 1
@@ -109,8 +105,8 @@ def test_append_entries_nonempty_discard():
     """test discarding an uncommitted entry from a past term"""
     term = 1
     new_term = 2
-    le0 = LogEntry(op=Op.WRITE, key='this', value='that', term=term)
-    le1 = LogEntry(op=Op.DELETE, key='this', value=None, term=term)
+    le0 = Entry(op=Op.WRITE, key='this', value='that', term=term)
+    le1 = Entry(op=Op.DELETE, key='this', value=None, term=term)
     # simulate a previous successful election and write
     s = State()
     s.currentTerm = term
@@ -119,16 +115,15 @@ def test_append_entries_nonempty_discard():
     s.lastApplied = 0
 
     # This should become the second log entry, replacing le1
-    le2 = LogEntry(op=Op.WRITE, key='this', value='other', term=term)
-    ae = AppendEntries(
-        term=new_term,
-        leaderId=0,
-        prevLogIndex=0,
-        prevLogTerm=1,
-        entries=[le2],
-        leaderCommit=0)
+    le2 = Entry(op=Op.WRITE, key='this', value='other', term=term)
 
-    res = s.append_entries_receiver(ae)
+    res = s.append_entries(
+        term=new_term,
+        leader_id=0,
+        prev_log_index=0,
+        prev_log_term=1,
+        entries=[le2],
+        leader_commit=0)
     assert res.success
     assert res.term == new_term
     assert len(s.log) == 2
@@ -141,22 +136,21 @@ def test_append_entries_invalid_term():
     """test non-empty heartbeat condition with expired term"""
     term = 2
     past_term = term-1
-    le0 = LogEntry(op=Op.WRITE, key='this', value='that', term=past_term)
+    le0 = Entry(op=Op.WRITE, key='this', value='that', term=past_term)
     # simulate a previous successful election and write
     s = State()
     s.currentTerm = term
     s.log = [le0]
 
-    le1 = LogEntry(op=Op.DELETE, key='this', value=None, term=past_term)
-    ae = AppendEntries(
-        term=past_term,
-        leaderId=0,
-        prevLogIndex=0,
-        prevLogTerm=past_term,
-        entries=[le1],
-        leaderCommit=0)
+    le1 = Entry(op=Op.DELETE, key='this', value=None, term=past_term)
 
-    res = s.append_entries_receiver(ae)
+    res = s.append_entries(
+        term=past_term,
+        leader_id=0,
+        prev_log_index=0,
+        prev_log_term=past_term,
+        entries=[le1],
+        leader_commit=0)
     assert not res.success
     assert res.term == term
     assert len(s.log) == 1
@@ -175,14 +169,13 @@ def test_append_entries_new_term():
     s.currentTerm = term
     s.role = Role.LEADER
 
-    ae = AppendEntries(
+    res = s.append_entries(
         term=new_term,
-        leaderId=0,
-        prevLogIndex=-1,
-        prevLogTerm=0,
-        leaderCommit=-1)
-
-    res = s.append_entries_receiver(ae)
+        leader_id=0,
+        prev_log_index=-1,
+        prev_log_term=0,
+        entries=list(),
+        leader_commit=-1)
     assert res.success
     assert res.term == new_term
     assert s.role == Role.FOLLOWER


### PR DESCRIPTION
All server code (FastAPI and pydantic) is now isolated to the `server` module and main.py. This pattern should be maintained in future development in order to make it possible to change one without affecting the other (for instance, if FastAPI is replaced with Flask or made pluggable)